### PR TITLE
feat: add Group and Expense API client layer

### DIFF
--- a/Frontend/lib/api.ts
+++ b/Frontend/lib/api.ts
@@ -7,6 +7,17 @@ import {
   UpdateProfileResponse,
   User,
   ApiError,
+  Group,
+  CreateGroupRequest,
+  CreateGroupResponse,
+  AddMemberRequest,
+  AddMemberResponse,
+  JoinGroupRequest,
+  JoinGroupResponse,
+  Expense,
+  CreateExpenseRequest,
+  CreateExpenseResponse,
+  SettlementResponse,
 } from "./types";
 
 // API Configuration
@@ -271,4 +282,82 @@ export const getAvatarUrl = (userId: string): string => {
 
 export const getPaymentQrUrl = (userId: string): string => {
   return `${API_BASE_URL}/user/${userId}/payment-qr`;
+};
+
+// Group API functions
+export const groupApi = {
+  // Create a new group
+  async createGroup(data: CreateGroupRequest): Promise<CreateGroupResponse> {
+    return apiRequest<CreateGroupResponse>("/groups", {
+      method: "POST",
+      body: JSON.stringify(data),
+    });
+  },
+
+  // Get all groups for current user
+  async getUserGroups(): Promise<Group[]> {
+    return apiRequest<Group[]>("/groups", {
+      method: "GET",
+    });
+  },
+
+  // Get group details by ID
+  async getGroupById(groupId: string): Promise<Group> {
+    return apiRequest<Group>(`/groups/${groupId}`, {
+      method: "GET",
+    });
+  },
+
+  // Add a member to group
+  async addMember(
+    groupId: string,
+    data: AddMemberRequest
+  ): Promise<AddMemberResponse> {
+    return apiRequest<AddMemberResponse>(`/groups/${groupId}/members`, {
+      method: "POST",
+      body: JSON.stringify(data),
+    });
+  },
+
+  // Join group using invite code (body)
+  async joinGroupByCode(data: JoinGroupRequest): Promise<JoinGroupResponse> {
+    return apiRequest<JoinGroupResponse>("/groups/join", {
+      method: "POST",
+      body: JSON.stringify(data),
+    });
+  },
+
+  // Join group using invite link (URL param)
+  async joinGroupByLink(inviteCode: string): Promise<JoinGroupResponse> {
+    return apiRequest<JoinGroupResponse>(`/groups/join/${inviteCode}`, {
+      method: "GET",
+    });
+  },
+
+  // Get all expenses in a group
+  async getGroupExpenses(groupId: string): Promise<Expense[]> {
+    return apiRequest<Expense[]>(`/groups/${groupId}/expenses`, {
+      method: "GET",
+    });
+  },
+
+  // Get settlement calculation for a group
+  async getSettlement(groupId: string): Promise<SettlementResponse> {
+    return apiRequest<SettlementResponse>(`/groups/${groupId}/settlement`, {
+      method: "GET",
+    });
+  },
+};
+
+// Expense API functions
+export const expenseApi = {
+  // Create a new expense
+  async createExpense(
+    data: CreateExpenseRequest
+  ): Promise<CreateExpenseResponse> {
+    return apiRequest<CreateExpenseResponse>("/expenses", {
+      method: "POST",
+      body: JSON.stringify(data),
+    });
+  },
 };

--- a/Frontend/lib/types.ts
+++ b/Frontend/lib/types.ts
@@ -72,3 +72,105 @@ export interface AuthContextType {
   refreshProfile: () => Promise<void>;
   updateProfile: (data: UpdateProfileRequest) => Promise<void>;
 }
+
+// Group models
+export interface Group {
+  id: string;
+  name: string;
+  description?: string | null;
+  inviteCode: string;
+  createdById: string;
+  createdBy?: User;
+  createdAt: string;
+  updatedAt: string;
+  members?: GroupMember[];
+  expenses?: Expense[];
+}
+
+export interface GroupMember {
+  id: string;
+  groupId: string;
+  userId: string;
+  user?: User;
+  joinedAt: string;
+}
+
+// Expense models
+export interface Expense {
+  id: string;
+  description: string;
+  amount: number;
+  paidById: string;
+  paidBy?: User;
+  groupId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// Group API request DTOs
+export interface CreateGroupRequest {
+  name: string;
+  description?: string;
+}
+
+export interface AddMemberRequest {
+  userId: string;
+}
+
+export interface JoinGroupRequest {
+  inviteCode: string;
+}
+
+// Expense API request DTOs
+export interface CreateExpenseRequest {
+  description: string;
+  amount: number;
+  groupId: string;
+}
+
+// Settlement response DTOs
+export interface MemberBalance {
+  userId: string;
+  userName: string;
+  totalPaid: number;
+  fairShare: number;
+  balance: number;
+}
+
+export interface Transaction {
+  fromUserId: string;
+  fromUserName: string;
+  toUserId: string;
+  toUserName: string;
+  amount: number;
+}
+
+export interface SettlementResponse {
+  totalExpenses: number;
+  memberCount: number;
+  fairSharePerPerson: number;
+  balances: MemberBalance[];
+  transactions: Transaction[];
+}
+
+// Group API response DTOs
+export interface CreateGroupResponse {
+  message: string;
+  group: Group;
+}
+
+export interface JoinGroupResponse {
+  message: string;
+  group: Group;
+}
+
+export interface AddMemberResponse {
+  message: string;
+  member: GroupMember;
+}
+
+// Expense API response DTOs
+export interface CreateExpenseResponse {
+  message: string;
+  expense: Expense;
+}


### PR DESCRIPTION


# 🚀 Pull Request

## 🧠 Mô tả

- Add Group, GroupMember, Expense type definitions
- Add API request/response DTOs for groups and expenses
- Add groupApi with 8 methods: createGroup, getUserGroups, getGroupById, addMember, joinGroupByCode, joinGroupByLink, getGroupExpenses, getSettlement
- Add expenseApi with createExpense method

---

## ✅ Checklist

> Kiểm tra trước khi gửi PR

-   [X] Đã pull `develop` mới nhất
-   [X] Đã chạy app và test tính năng
-   [X] Code tuân thủ convention của team
-   [X] Không chứa log hoặc console không cần thiết
-   [X] Đã được review local (nếu có pair)
---

## 🧩 Thay đổi chính

> Liệt kê chi tiết phần thay đổi (FE/BE)
### ⚙️ Backend

-   [X] New API
-   [X] Update Service / Controller

---

## 🧪 Cách test

> Hướng dẫn reviewer test nhanh

Ví dụ:

1. Chạy `docker-compose up`
2. Vào `/groups`
3. Kiểm tra có thể thêm group mới thành công

---

## 👀 Reviewer

> Gắn ít nhất 1 người review

@CrazyMeowl 

---

🟢 **Lưu ý:**

-   Không merge PR khi chưa có ít nhất **1 approval**
-   PR phải merge vào `develop`
