### PR TITLE
fix: correct getUserGroups API response type

### DIFF
--- a/Frontend/app/groups/page.tsx
+++ b/Frontend/app/groups/page.tsx
@@ -36,7 +36,7 @@ export default function GroupsPage() {
       setIsLoading(true);
       setError(null);
       const data = await groupApi.getUserGroups();
-      setGroups(data);
+      setGroups(data.groups);
     } catch (err) {
       console.error("Failed to load groups:", err);
       setError(err instanceof Error ? err.message : "Không thể tải danh sách nhóm");

--- a/Frontend/lib/api.ts
+++ b/Frontend/lib/api.ts
@@ -196,8 +196,8 @@ export const groupApi = {
   },
 
   // Get all groups for current user
-  async getUserGroups(): Promise<Group[]> {
-    return apiRequest<Group[]>("/groups", {
+  async getUserGroups(): Promise<{ groups: Group[] }> {
+    return apiRequest<{ groups: Group[] }>("/groups", {
       method: "GET",
     });
   },


### PR DESCRIPTION

# 🚀 Pull Request

## 🧠 Mô tả

> Tóm tắt ngắn gọn thay đổi của PR này (chức năng chính, file nào ảnh hưởng, lý do cần thay đổi)
- Update `getUserGroups()` return type to `Promise<{ groups: Group[] }>`
- Access `data.groups` instead of `data` directly in groups page

---

## ✅ Checklist

> Kiểm tra trước khi gửi PR

-   [X] Đã pull `develop` mới nhất
-   [X] Đã chạy app và test tính năng
-   [X] Code tuân thủ convention của team
-   [X] Không chứa log hoặc console không cần thiết
-   [X] Đã được review local (nếu có pair)

---

## 🧩 Thay đổi chính

> Liệt kê chi tiết phần thay đổi (FE/BE)

### 🖥️ Frontend
-   [X] Logic / Validation
---

## 🧪 Cách test

> Hướng dẫn reviewer test nhanh

Ví dụ:

1. Chạy `docker-compose up`
2. Vào `/groups`
3. Kiểm tra có thể thêm group mới thành công

---

## 👀 Reviewer

> Gắn ít nhất 1 người review

@CrazyMeowl 

---

🟢 **Lưu ý:**

-   Không merge PR khi chưa có ít nhất **1 approval**
-   PR phải merge vào `develop`
