### PR TITLE
feat: add delete expense feature for expense owners

### DIFF
--- a/Frontend/lib/api.ts
+++ b/Frontend/lib/api.ts
@@ -262,6 +262,13 @@ export const expenseApi = {
       body: JSON.stringify(data),
     });
   },
+
+  // Delete an expense (owner only)
+  async deleteExpense(expenseId: string): Promise<{ message: string }> {
+    return apiRequest<{ message: string }>(`/expenses/${expenseId}`, {
+      method: "DELETE",
+    });
+  },
 };
 
 // Token management utilities

--- a/backend/src/expense/expense.controller.ts
+++ b/backend/src/expense/expense.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   Post,
+  Delete,
   Body,
   Param,
   UseGuards,
@@ -25,5 +26,14 @@ export class ExpenseController {
   @ApiResponse({ status: 201, description: 'Expense created', type: Object })
   createExpense(@Request() req: any, @Body() createExpenseDto: CreateExpenseDto) {
     return this.expenseService.createExpense(req.user.sub, createExpenseDto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete an expense (owner only)' })
+  @ApiResponse({ status: 200, description: 'Expense deleted successfully' })
+  @ApiResponse({ status: 403, description: 'Only expense owner can delete' })
+  @ApiResponse({ status: 404, description: 'Expense not found' })
+  deleteExpense(@Request() req: any, @Param('id') expenseId: string) {
+    return this.expenseService.deleteExpense(req.user.sub, expenseId);
   }
 }


### PR DESCRIPTION
# 🚀 Pull Request

## 🧠 Mô tả

> Tóm tắt ngắn gọn thay đổi của PR này (chức năng chính, file nào ảnh hưởng, lý do cần thay đổi)

- Add DELETE /expenses/:id endpoint in backend with ownership validation
- Only expense owner (paidById) can delete their expense, return 403 Forbidden if non-owner attempts
- Add deleteExpense method to frontend API client
- Add trash icon button in expense list for owners only
- Show loading spinner while deleting
- Reload group data after successful deletion
- Add confirmation dialog before deleting expense

---

## ✅ Checklist

> Kiểm tra trước khi gửi PR

-   [X] Đã pull `develop` mới nhất
-   [X] Đã chạy app và test tính năng
-   [X] Code tuân thủ convention của team
-   [X] Không chứa log hoặc console không cần thiết
-   [X] Đã được review local (nếu có pair)
---

## 🧩 Thay đổi chính

> Liệt kê chi tiết phần thay đổi (FE/BE)

### ⚙️ Backend

-   [X] New API
-   [X] Update Service / Controller
-   [X] Database schema (nếu có)

---

## 🧪 Cách test

> Hướng dẫn reviewer test nhanh

Ví dụ:

1. Chạy `docker-compose up`
2. Vào `/groups`
3. Kiểm tra có thể thêm group mới thành công

---

## 👀 Reviewer

> Gắn ít nhất 1 người review

@CrazyMeowl 

---

🟢 **Lưu ý:**

-   Không merge PR khi chưa có ít nhất **1 approval**
-   PR phải merge vào `develop`
