### PR TITLE
feat: add delete expense feature for expense owners

### DIFF
--- a/Frontend/app/groups/[id]/page.tsx
+++ b/Frontend/app/groups/[id]/page.tsx
@@ -21,6 +21,7 @@ import {
   ArrowRight,
   AlertCircle,
   ArrowLeft,
+  Trash2,
 } from "lucide-react";
 import { ErrorAlert } from "@/components/ui/error-alert";
 import { useAuth } from "@/contexts/AuthContext";
@@ -57,7 +58,7 @@ const getInitials = (value?: string | null): string => {
 export default function GroupDetailPage() {
   const router = useRouter();
   const params = useParams<{ id?: string | string[] }>();
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, user } = useAuth();
 
   const groupId = Array.isArray(params?.id)
     ? params.id[0] ?? ""
@@ -75,6 +76,7 @@ export default function GroupDetailPage() {
   const [newExpenseDescription, setNewExpenseDescription] = useState("");
   const [newExpenseAmount, setNewExpenseAmount] = useState("");
   const [isCreatingExpense, setIsCreatingExpense] = useState(false);
+  const [deletingExpenseId, setDeletingExpenseId] = useState<string | null>(null);
 
   // Add member state
   const [showAddMemberForm, setShowAddMemberForm] = useState(false);
@@ -194,6 +196,26 @@ export default function GroupDetailPage() {
       alert(message);
     } finally {
       setIsCreatingExpense(false);
+    }
+  };
+
+  const handleDeleteExpense = async (expenseId: string) => {
+    if (!confirm("Bạn có chắc muốn xóa chi tiêu này?")) {
+      return;
+    }
+
+    setDeletingExpenseId(expenseId);
+    try {
+      await expenseApi.deleteExpense(expenseId);
+      // Reload data to reflect the deletion
+      await loadData("refresh");
+    } catch (error) {
+      console.error("Failed to delete expense", error);
+      const message =
+        error instanceof Error ? error.message : "Không thể xóa chi tiêu.";
+      alert(message);
+    } finally {
+      setDeletingExpenseId(null);
     }
   };
 
@@ -552,9 +574,26 @@ export default function GroupDetailPage() {
                       {expense.paidBy?.email})
                     </p>
                   </div>
-                  <p className="font-semibold text-primary">
-                    {formatCurrency(expense.amount)}
-                  </p>
+                  <div className="flex items-center gap-2">
+                    <p className="font-semibold text-primary">
+                      {formatCurrency(expense.amount)}
+                    </p>
+                    {user?.id === expense.paidById && (
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => handleDeleteExpense(expense.id)}
+                        disabled={deletingExpenseId === expense.id}
+                        className="text-destructive hover:text-destructive hover:bg-destructive/10"
+                      >
+                        {deletingExpenseId === expense.id ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <Trash2 className="h-4 w-4" />
+                        )}
+                      </Button>
+                    )}
+                  </div>
                 </div>
               ))
             )}

--- a/Frontend/lib/api.ts
+++ b/Frontend/lib/api.ts
@@ -262,6 +262,13 @@ export const expenseApi = {
       body: JSON.stringify(data),
     });
   },
+
+  // Delete an expense (owner only)
+  async deleteExpense(expenseId: string): Promise<{ message: string }> {
+    return apiRequest<{ message: string }>(`/expenses/${expenseId}`, {
+      method: "DELETE",
+    });
+  },
 };
 
 // Token management utilities

--- a/backend/src/expense/expense.controller.ts
+++ b/backend/src/expense/expense.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   Post,
+  Delete,
   Body,
   Param,
   UseGuards,
@@ -25,5 +26,14 @@ export class ExpenseController {
   @ApiResponse({ status: 201, description: 'Expense created', type: Object })
   createExpense(@Request() req: any, @Body() createExpenseDto: CreateExpenseDto) {
     return this.expenseService.createExpense(req.user.sub, createExpenseDto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete an expense (owner only)' })
+  @ApiResponse({ status: 200, description: 'Expense deleted successfully' })
+  @ApiResponse({ status: 403, description: 'Only expense owner can delete' })
+  @ApiResponse({ status: 404, description: 'Expense not found' })
+  deleteExpense(@Request() req: any, @Param('id') expenseId: string) {
+    return this.expenseService.deleteExpense(req.user.sub, expenseId);
   }
 }


### PR DESCRIPTION
# 🚀 Pull Request

## 🧠 Mô tả

> Tóm tắt ngắn gọn thay đổi của PR này (chức năng chính, file nào ảnh hưởng, lý do cần thay đổi)

- Add DELETE /expenses/:id endpoint with ownership validation
- Add deleteExpense method to frontend API client
- Display trash icon button for expense owners only
- Show loading spinner during deletion
- Reload group data after successful deletion
- Confirm dialog before deleting expense
---

## ✅ Checklist

> Kiểm tra trước khi gửi PR

-   [X] Đã pull `develop` mới nhất
-   [X] Đã chạy app và test tính năng
-   [X] Code tuân thủ convention của team
-   [X] Không chứa log hoặc console không cần thiết
-   [X] Đã được review local (nếu có pair)

---

## 🧩 Thay đổi chính

> Liệt kê chi tiết phần thay đổi (FE/BE)
### ⚙️ Backend

-   [X] New API
-   [X] Update Service / Controller
-   [X] Business logic

---

## 🧪 Cách test

> Hướng dẫn reviewer test nhanh

Ví dụ:

1. Chạy `docker-compose up`
2. Vào `/groups`
3. Kiểm tra có thể thêm group mới thành công

---

## 👀 Reviewer

> Gắn ít nhất 1 người review

@CrazyMeowl 

---

🟢 **Lưu ý:**

-   Không merge PR khi chưa có ít nhất **1 approval**
-   PR phải merge vào `develop`
